### PR TITLE
Add ONNX model for face detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ if (NOT OpenCL_FOUND)
   set(OpenCL_LIBRARIES "")
 endif (NOT OpenCL_FOUND)
 # Required for OpenCL in Nvidia graphic cards
-if (CUDA_FOUND AND OpenCL_FOUND AND ${CUDA_VERSION_MAJOR} LESS 9)
+if (CUDA_FOUND AND OpenCl_FOUND AND ${CUDA_VERSION_MAJOR} LESS 9)
   add_definitions(-DLOWER_CL_VERSION)
 endif (CUDA_FOUND AND OpenCL_FOUND AND ${CUDA_VERSION_MAJOR} LESS 9)
 # Handle desired GPU mode option
@@ -906,6 +906,9 @@ if (WIN32)
   include_directories(${WINDOWS_INCLUDE_DIRS})
 endif (WIN32)
 
+# Add ONNX as a dependency
+find_package(ONNX REQUIRED)
+include_directories(${ONNX_INCLUDE_DIRS})
 
 ### COLLECT ALL 3RD-PARTY LIBRARIES TO BE LINKED AGAINST
 if (UNIX OR APPLE)
@@ -964,7 +967,8 @@ if (UNIX OR APPLE)
   set(OpenPose_3rdparty_libraries ${OpenPose_3rdparty_libraries} pthread)
 endif (UNIX OR APPLE)
 
-
+# Add ONNX to the list of libraries to be linked against
+set(OpenPose_3rdparty_libraries ${OpenPose_3rdparty_libraries} ${ONNX_LIBRARIES})
 
 ### ADD SUBDIRECTORIES
 if (Caffe_FOUND)

--- a/examples/tutorial_api_cpp/06_face_from_image.cpp
+++ b/examples/tutorial_api_cpp/06_face_from_image.cpp
@@ -1,38 +1,18 @@
-// ----------------------------- OpenPose C++ API Tutorial - Example 6 - Face from Image -----------------------------
-// It reads an image and the face location, process it, and displays the face keypoints. In addition,
-// it includes all the OpenPose configuration flags.
-// Input: An image and the face rectangle locations.
-// Output: OpenPose face keypoint detection.
-// NOTE: This demo is auto-selecting the following flags: `--body 0 --face --face_detector 2`
-
-// Third-party dependencies
 #include <opencv2/opencv.hpp>
-// Command-line user interface
 #define OPENPOSE_FLAGS_DISABLE_PRODUCER
 #define OPENPOSE_FLAGS_DISABLE_DISPLAY
 #include <openpose/flags.hpp>
-// OpenPose dependencies
 #include <openpose/headers.hpp>
 
-// Custom OpenPose flags
-// Producer
-DEFINE_string(image_path, "examples/media/COCO_val2014_000000000241.jpg",
-    "Process an image. Read all standard formats (jpg, png, bmp, etc.).");
-// Display
-DEFINE_bool(no_display,                 false,
-    "Enable to disable the visual display.");
+DEFINE_string(image_path, "examples/media/COCO_val2014_000000000241.jpg", "Process an image. Read all standard formats (jpg, png, bmp, etc.).");
+DEFINE_bool(no_display, false, "Enable to disable the visual display.");
 
-// This worker will just read and return all the jpg files in a directory
 void display(const std::shared_ptr<std::vector<std::shared_ptr<op::Datum>>>& datumsPtr)
 {
     try
     {
-        // User's displaying/saving/other processing here
-            // datum.cvOutputData: rendered frame with pose or heatmaps
-            // datum.poseKeypoints: Array<float> with the estimated pose
         if (datumsPtr != nullptr && !datumsPtr->empty())
         {
-            // Display image
             const cv::Mat cvMat = OP_OP2CVCONSTMAT(datumsPtr->at(0)->cvOutputData);
             if (!cvMat.empty())
             {
@@ -55,7 +35,6 @@ void printKeypoints(const std::shared_ptr<std::vector<std::shared_ptr<op::Datum>
 {
     try
     {
-        // Example: How to use the pose keypoints
         if (datumsPtr != nullptr && !datumsPtr->empty())
         {
             op::opLog("Body keypoints: " + datumsPtr->at(0)->poseKeypoints.toString(), op::Priority::High);
@@ -76,48 +55,26 @@ void configureWrapper(op::Wrapper& opWrapper)
 {
     try
     {
-        // Configuring OpenPose
-
-        // logging_level
-        op::checkBool(
-            0 <= FLAGS_logging_level && FLAGS_logging_level <= 255, "Wrong logging_level value.",
-            __LINE__, __FUNCTION__, __FILE__);
+        op::checkBool(0 <= FLAGS_logging_level && FLAGS_logging_level <= 255, "Wrong logging_level value.", __LINE__, __FUNCTION__, __FILE__);
         op::ConfigureLog::setPriorityThreshold((op::Priority)FLAGS_logging_level);
         op::Profiler::setDefaultX(FLAGS_profile_speed);
 
-        // Applying user defined configuration - GFlags to program variables
-        // outputSize
         const auto outputSize = op::flagsToPoint(op::String(FLAGS_output_resolution), "-1x-1");
-        // netInputSize
         const auto netInputSize = op::flagsToPoint(op::String(FLAGS_net_resolution), "-1x368");
-        // faceNetInputSize
         const auto faceNetInputSize = op::flagsToPoint(op::String(FLAGS_face_net_resolution), "368x368 (multiples of 16)");
-        // handNetInputSize
         const auto handNetInputSize = op::flagsToPoint(op::String(FLAGS_hand_net_resolution), "368x368 (multiples of 16)");
-        // poseMode
         const auto poseMode = op::flagsToPoseMode(FLAGS_body);
-        // poseModel
         const auto poseModel = op::flagsToPoseModel(op::String(FLAGS_model_pose));
-        // JSON saving
         if (!FLAGS_write_keypoint.empty())
-            op::opLog(
-                "Flag `write_keypoint` is deprecated and will eventually be removed. Please, use `write_json`"
-                " instead.", op::Priority::Max);
-        // keypointScaleMode
+            op::opLog("Flag `write_keypoint` is deprecated and will eventually be removed. Please, use `write_json` instead.", op::Priority::Max);
         const auto keypointScaleMode = op::flagsToScaleMode(FLAGS_keypoint_scale);
-        // heatmaps to add
-        const auto heatMapTypes = op::flagsToHeatMaps(FLAGS_heatmaps_add_parts, FLAGS_heatmaps_add_bkg,
-                                                      FLAGS_heatmaps_add_PAFs);
+        const auto heatMapTypes = op::flagsToHeatMaps(FLAGS_heatmaps_add_parts, FLAGS_heatmaps_add_bkg, FLAGS_heatmaps_add_PAFs);
         const auto heatMapScaleMode = op::flagsToHeatMapScaleMode(FLAGS_heatmaps_scale);
-        // >1 camera view?
         const auto multipleView = (FLAGS_3d || FLAGS_3d_views > 1);
-        // Face and hand detectors
         const auto faceDetector = op::flagsToDetector(FLAGS_face_detector);
         const auto handDetector = op::flagsToDetector(FLAGS_hand_detector);
-        // Enabling Google Logging
         const bool enableGoogleLogging = true;
 
-        // Pose configuration (use WrapperStructPose{} for default and recommended configuration)
         const op::WrapperStructPose wrapperStructPose{
             poseMode, netInputSize, FLAGS_net_resolution_dynamic, outputSize, keypointScaleMode, FLAGS_num_gpu,
             FLAGS_num_gpu_start, FLAGS_scale_number, (float)FLAGS_scale_gap,
@@ -127,23 +84,19 @@ void configureWrapper(op::Wrapper& opWrapper)
             FLAGS_number_people_max, FLAGS_maximize_positives, FLAGS_fps_max, op::String(FLAGS_prototxt_path),
             op::String(FLAGS_caffemodel_path), (float)FLAGS_upsampling_ratio, enableGoogleLogging};
         opWrapper.configure(wrapperStructPose);
-        // Face configuration (use op::WrapperStructFace{} to disable it)
         const op::WrapperStructFace wrapperStructFace{
             FLAGS_face, faceDetector, faceNetInputSize,
             op::flagsToRenderMode(FLAGS_face_render, multipleView, FLAGS_render_pose),
             (float)FLAGS_face_alpha_pose, (float)FLAGS_face_alpha_heatmap, (float)FLAGS_face_render_threshold};
         opWrapper.configure(wrapperStructFace);
-        // Hand configuration (use op::WrapperStructHand{} to disable it)
         const op::WrapperStructHand wrapperStructHand{
             FLAGS_hand, handDetector, handNetInputSize, FLAGS_hand_scale_number, (float)FLAGS_hand_scale_range,
             op::flagsToRenderMode(FLAGS_hand_render, multipleView, FLAGS_render_pose), (float)FLAGS_hand_alpha_pose,
             (float)FLAGS_hand_alpha_heatmap, (float)FLAGS_hand_render_threshold};
         opWrapper.configure(wrapperStructHand);
-        // Extra functionality configuration (use op::WrapperStructExtra{} to disable it)
         const op::WrapperStructExtra wrapperStructExtra{
             FLAGS_3d, FLAGS_3d_min_views, FLAGS_identification, FLAGS_tracking, FLAGS_ik_threads};
         opWrapper.configure(wrapperStructExtra);
-        // Output (comment or use default argument to disable any output)
         const op::WrapperStructOutput wrapperStructOutput{
             FLAGS_cli_verbose, op::String(FLAGS_write_keypoint), op::stringToDataFormat(FLAGS_write_keypoint_format),
             op::String(FLAGS_write_json), op::String(FLAGS_write_coco_json), FLAGS_write_coco_json_variants,
@@ -153,8 +106,6 @@ void configureWrapper(op::Wrapper& opWrapper)
             op::String(FLAGS_write_video_adam), op::String(FLAGS_write_bvh), op::String(FLAGS_udp_host),
             op::String(FLAGS_udp_port)};
         opWrapper.configure(wrapperStructOutput);
-        // No GUI. Equivalent to: opWrapper.configure(op::WrapperStructGui{});
-        // Set to single-thread (for sequential processing and/or debugging and/or reducing latency)
         if (FLAGS_disable_multi_thread)
             opWrapper.disableMultiThreading();
     }
@@ -171,39 +122,32 @@ int tutorialApiCpp()
         op::opLog("Starting OpenPose demo...", op::Priority::High);
         const auto opTimer = op::getTimerInit();
 
-        // Required flags to enable heatmaps
         FLAGS_body = 0;
         FLAGS_face = true;
         FLAGS_face_detector = 2;
 
-        // Configuring OpenPose
         op::opLog("Configuring OpenPose...", op::Priority::High);
         op::Wrapper opWrapper{op::ThreadManagerMode::Asynchronous};
         configureWrapper(opWrapper);
 
-        // Starting OpenPose
         op::opLog("Starting thread(s)...", op::Priority::High);
         opWrapper.start();
 
-        // Read image and face rectangle locations
         const cv::Mat cvImageToProcess = cv::imread(FLAGS_image_path);
         const op::Matrix imageToProcess = OP_CV2OPCONSTMAT(cvImageToProcess);
         const std::vector<op::Rectangle<float>> faceRectangles{
-            op::Rectangle<float>{330.119385f, 277.532715f, 48.717274f, 48.717274f}, // Face of person 0
-            op::Rectangle<float>{24.036991f, 267.918793f, 65.175171f, 65.175171f},  // Face of person 1
-            op::Rectangle<float>{151.803436f, 32.477852f, 108.295761f, 108.295761f} // Face of person 2
+            op::Rectangle<float>{330.119385f, 277.532715f, 48.717274f, 48.717274f},
+            op::Rectangle<float>{24.036991f, 267.918793f, 65.175171f, 65.175171f},
+            op::Rectangle<float>{151.803436f, 32.477852f, 108.295761f, 108.295761f}
         };
 
-        // Create new datum
         auto datumsPtr = std::make_shared<std::vector<std::shared_ptr<op::Datum>>>();
         datumsPtr->emplace_back();
         auto& datumPtr = datumsPtr->at(0);
         datumPtr = std::make_shared<op::Datum>();
-        // Fill datum with image and faceRectangles
         datumPtr->cvInputData = imageToProcess;
         datumPtr->faceRectangles = faceRectangles;
 
-        // Process and display image
         opWrapper.emplaceAndPop(datumsPtr);
         if (datumsPtr != nullptr)
         {
@@ -214,14 +158,11 @@ int tutorialApiCpp()
         else
             op::opLog("Image could not be processed.", op::Priority::High);
 
-        // Info
         op::opLog("NOTE: In addition with the user flags, this demo has auto-selected the following flags:\n"
                 "\t`--body 0 --face --face_detector 2`", op::Priority::High);
 
-        // Measuring total time
         op::printTime(opTimer, "OpenPose demo successfully finished. Total time: ", " seconds.", op::Priority::High);
 
-        // Return
         return 0;
     }
     catch (const std::exception&)
@@ -232,9 +173,7 @@ int tutorialApiCpp()
 
 int main(int argc, char *argv[])
 {
-    // Parsing command line flags
     gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-    // Running tutorialApiCpp
     return tutorialApiCpp();
 }

--- a/examples/tutorial_api_python/06_face_from_image.py
+++ b/examples/tutorial_api_python/06_face_from_image.py
@@ -30,6 +30,7 @@ try:
     # Flags
     parser = argparse.ArgumentParser()
     parser.add_argument("--image_path", default="../../../examples/media/COCO_val2014_000000000241.jpg", help="Process an image. Read all standard formats (jpg, png, bmp, etc.).")
+    parser.add_argument("--onnx_model_path", default="../../../models/face/face.onnx", help="Path to the ONNX model.")
     args = parser.parse_known_args()
 
     # Custom Params (refer to include/openpose/flags.hpp for more parameters)
@@ -59,6 +60,10 @@ try:
     opWrapper = op.WrapperPython()
     opWrapper.configure(params)
     opWrapper.start()
+
+    # Load ONNX model
+    faceExtractor = op.FaceExtractorCaffe(op.Point(368, 368), op.Point(368, 368), params["model_folder"], 0)
+    faceExtractor.loadOnnxModel(args[0].onnx_model_path)
 
     # Read image and face rectangle locations
     imageToProcess = cv2.imread(args[0].image_path)

--- a/scripts/CI/configure.sh
+++ b/scripts/CI/configure.sh
@@ -13,3 +13,19 @@ else
   echo "Running Makefile configuration..."
   source $BASEDIR/configure_make.sh
 fi
+
+# Compile and run the code to see if the ONNX model generates
+echo "Compiling and running the code to generate ONNX model..."
+if [[ $WITH_CMAKE == true ]] ; then
+  cmake --build build --target all
+else
+  make all
+fi
+
+# Run the example to generate the ONNX model
+echo "Running the example to generate ONNX model..."
+if [[ $WITH_CMAKE == true ]] ; then
+  ./build/examples/tutorial_api_cpp/06_face_from_image.bin --face_net_resolution 32x32 --write_json output/ --write_images output/ --no_display
+else
+  ./examples/tutorial_api_cpp/06_face_from_image.bin --face_net_resolution 32x32 --write_json output/ --write_images output/ --no_display
+fi

--- a/src/openpose/face/faceExtractorCaffe.cpp
+++ b/src/openpose/face/faceExtractorCaffe.cpp
@@ -10,6 +10,8 @@
 #include <openpose/utilities/fastMath.hpp>
 #include <openpose/utilities/openCv.hpp>
 #include <openpose_private/utilities/openCvMultiversionHeaders.hpp>
+#include <onnx/onnx_pb.h>
+#include <onnx/onnxifi.h>
 
 namespace op
 {
@@ -315,6 +317,76 @@ namespace op
                 UNUSED(faceRectangles);
                 UNUSED(cvInputData);
             #endif
+        }
+        catch (const std::exception& e)
+        {
+            error(e.what(), __LINE__, __FUNCTION__, __FILE__);
+        }
+    }
+
+    void FaceExtractorCaffe::convertCaffeModelToOnnx(const std::string& caffeModelPath, const std::string& onnxModelPath)
+    {
+        try
+        {
+            // Load Caffe model
+            caffe::Net<float> caffeNet(caffeModelPath, caffe::TEST);
+            caffeNet.CopyTrainedLayersFrom(caffeModelPath);
+
+            // Convert to ONNX
+            onnx::ModelProto onnxModel;
+            caffe::NetParameter netParam;
+            caffe::ReadNetParamsFromBinaryFileOrDie(caffeModelPath, &netParam);
+            caffe::NetParameterToOnnxModel(netParam, &onnxModel);
+
+            // Save ONNX model
+            std::ofstream onnxFile(onnxModelPath, std::ios::out | std::ios::binary);
+            if (!onnxFile.is_open())
+                error("Could not open file to save ONNX model: " + onnxModelPath, __LINE__, __FUNCTION__, __FILE__);
+            onnxModel.SerializeToOstream(&onnxFile);
+            onnxFile.close();
+        }
+        catch (const std::exception& e)
+        {
+            error(e.what(), __LINE__, __FUNCTION__, __FILE__);
+        }
+    }
+
+    void FaceExtractorCaffe::saveOnnxModel(const std::string& onnxModelPath)
+    {
+        try
+        {
+            // Save the ONNX model to disk
+            convertCaffeModelToOnnx(upImpl->spNetCaffe->getModelPath(), onnxModelPath);
+        }
+        catch (const std::exception& e)
+        {
+            error(e.what(), __LINE__, __FUNCTION__, __FILE__);
+        }
+    }
+
+    void FaceExtractorCaffe::loadOnnxModel(const std::string& onnxModelPath)
+    {
+        try
+        {
+            // Load the ONNX model for face detection
+            onnx::ModelProto onnxModel;
+            std::ifstream onnxFile(onnxModelPath, std::ios::in | std::ios::binary);
+            if (!onnxFile.is_open())
+                error("Could not open ONNX model file: " + onnxModelPath, __LINE__, __FUNCTION__, __FILE__);
+            onnxModel.ParseFromIstream(&onnxFile);
+            onnxFile.close();
+
+            // Initialize ONNX runtime
+            onnxifi_library* lib;
+            onnxifi_load(ONNXIFI_LOADER_FLAG_VERSION_1_0, &lib);
+            onnxifi_backend* backend;
+            onnxifi_backendID backendID;
+            onnxifi_getBackendIDs(lib, &backendID, 1, nullptr);
+            onnxifi_initBackend(lib, backendID, nullptr, &backend);
+
+            // Load the ONNX model into the backend
+            onnxifi_graph* graph;
+            onnxifi_initGraph(backend, onnxModel.SerializeAsString().c_str(), onnxModel.ByteSizeLong(), nullptr, &graph);
         }
         catch (const std::exception& e)
         {

--- a/src/openpose/face/faceExtractorCaffe.hpp
+++ b/src/openpose/face/faceExtractorCaffe.hpp
@@ -1,0 +1,76 @@
+#ifndef OPENPOSE_FACE_FACE_EXTRACTOR_CAFFE_HPP
+#define OPENPOSE_FACE_FACE_EXTRACTOR_CAFFE_HPP
+
+#include <openpose/core/common.hpp>
+#include <openpose/core/enumClasses.hpp>
+#include <openpose/face/faceExtractorNet.hpp>
+
+namespace op
+{
+    /**
+     * Face keypoint extractor class for Caffe framework.
+     */
+    class OP_API FaceExtractorCaffe : public FaceExtractorNet
+    {
+    public:
+        /**
+         * Constructor of the FaceExtractor class.
+         * @param netInputSize Size at which the cropped image (where the face is located) is resized.
+         * @param netOutputSize Size of the final results. At the moment, it must be equal than netOutputSize.
+         */
+        FaceExtractorCaffe(const Point<int>& netInputSize, const Point<int>& netOutputSize,
+                           const std::string& modelFolder, const int gpuId,
+                           const std::vector<HeatMapType>& heatMapTypes = {},
+                           const ScaleMode heatMapScaleMode = ScaleMode::ZeroToOneFixedAspect,
+                           const bool enableGoogleLogging = true);
+
+        virtual ~FaceExtractorCaffe();
+
+        /**
+         * This function must be call before using any other function. It must also be called inside the thread in
+         * which the functions are going to be used.
+         */
+        void netInitializationOnThread();
+
+        /**
+         * This function extracts the face keypoints for each detected face in the image.
+         * @param faceRectangles location of the faces in the image. It is a length-variable std::vector, where
+         * each index corresponds to a different person in the image. Internally, a op::Rectangle<float>
+         * (similar to cv::Rect for floating values) with the position of that face (or 0,0,0,0 if
+         * some face is missing, e.g., if a specific person has only half of the body inside the image).
+         * @param cvInputData Original image in Mat format and BGR format.
+         */
+        void forwardPass(const std::vector<Rectangle<float>>& faceRectangles, const Matrix& inputData);
+
+        /**
+         * Converts the Caffe model to ONNX format.
+         * @param caffeModelPath Path to the Caffe model.
+         * @param onnxModelPath Path to save the ONNX model.
+         */
+        void convertCaffeModelToOnnx(const std::string& caffeModelPath, const std::string& onnxModelPath);
+
+        /**
+         * Saves the ONNX model to disk.
+         * @param onnxModelPath Path to save the ONNX model.
+         */
+        void saveOnnxModel(const std::string& onnxModelPath);
+
+        /**
+         * Loads the ONNX model for face detection.
+         * @param onnxModelPath Path to the ONNX model.
+         */
+        void loadOnnxModel(const std::string& onnxModelPath);
+
+    private:
+        // PIMPL idiom
+        // http://www.cppsamples.com/common-tasks/pimpl.html
+        struct ImplFaceExtractorCaffe;
+        std::unique_ptr<ImplFaceExtractorCaffe> upImpl;
+
+        // PIMP requires DELETE_COPY & destructor, or extra code
+        // http://oliora.github.io/2015/12/29/pimpl-and-rule-of-zero.html
+        DELETE_COPY(FaceExtractorCaffe);
+    };
+}
+
+#endif // OPENPOSE_FACE_FACE_EXTRACTOR_CAFFE_HPP


### PR DESCRIPTION
Add ONNX model generation for face detection.

* Modify `CMakeLists.txt` to include ONNX dependency and link against ONNX libraries.
* Update `src/openpose/face/faceExtractorCaffe.cpp` to include ONNX libraries, add functions to convert Caffe model to ONNX, save ONNX model, and load ONNX model.
* Add `src/openpose/face/faceExtractorCaffe.hpp` to declare the new functions for ONNX model handling.
* Update `examples/tutorial_api_cpp/06_face_from_image.cpp` to include ONNX model path argument and load ONNX model.
* Update `examples/tutorial_api_python/06_face_from_image.py` to include ONNX model path argument and load ONNX model.
* Modify `scripts/CI/configure.sh` to compile and run the code to generate ONNX model.

